### PR TITLE
⚡ Bolt: Optimize usePosts to fetch partial content by default

### DIFF
--- a/app/search/SearchContent.jsx
+++ b/app/search/SearchContent.jsx
@@ -84,7 +84,7 @@ const saveRecentSearch = (query) => {
 
 export default function SearchPage({ isWindowMode = false }) {
     const router = useRouter();
-    const { posts, loading } = usePosts();
+    const { posts, loading } = usePosts({ fetchContent: true });
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('all');


### PR DESCRIPTION
💡 What:
Updated `usePosts` hook to select only necessary metadata columns (`id`, `title`, `excerpt`, etc.) by default, instead of `SELECT *`.
Added a `{ fetchContent: boolean }` option to `usePosts` to allow opting into full content fetching when needed.
Updated `SearchContent` to use `{ fetchContent: true }` as it requires full content for client-side search.

🎯 Why:
The `posts` table contains a `content` column which can be large (Markdown).
Most views (Home, Dashboard, Explore) only display metadata cards and do not need the full content.
Fetching the full content for all posts on the home page causes unnecessary data transfer and slower initial load.

📊 Impact:
Reduces the data payload size for `usePosts` by excluding the `content` field.
Specifically benefits the `HomeWindow`, `Dashboard`, and `ExploreContent` components.

🔬 Measurement:
Verified via code inspection that `postsFetcher` selects specific columns when `fetchContent` is false.
Verified `SearchContent` still requests full content.
Tests passed.

---
*PR created automatically by Jules for task [18285338498745256650](https://jules.google.com/task/18285338498745256650) started by @malidk345*