### PR TITLE
⚡ Bolt: Optimize usePosts to fetch partial data by default

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Default Data Over-fetching
+**Learning:** The `usePosts` hook was fetching all columns (including heavy markdown `content`) by default, causing performance issues on list views. Supabase `select('*')` is costly for large text fields.
+**Action:** Default to fetching only metadata columns in hooks. Use a specific option `{ fetchContent: true }` when full content is required (e.g., search, single post view). Always construct SWR/query keys to distinguish between partial and full data to avoid cache pollution.

--- a/app/hooks/usePosts.js
+++ b/app/hooks/usePosts.js
@@ -49,10 +49,15 @@ const adaptPost = (p) => {
     };
 };
 
-const postsFetcher = async () => {
+const postsFetcher = async (options = {}) => {
+    const { fetchContent } = options;
+    const selectColumns = fetchContent
+        ? '*'
+        : 'id, slug, title, created_at, category, excerpt, author, author_avatar, image_url, published';
+
     const { data, error } = await supabase
         .from('posts')
-        .select('*')
+        .select(selectColumns)
         .eq('published', true)
         .order('created_at', { ascending: false });
 
@@ -60,11 +65,15 @@ const postsFetcher = async () => {
     return data.map(adaptPost).filter(Boolean);
 };
 
-export const usePosts = () => {
-    const { data, error, isLoading, mutate } = useSWR('posts', postsFetcher, {
-        revalidateOnFocus: false,
-        dedupingInterval: 60000, // 1 minute
-    });
+export const usePosts = ({ fetchContent = false } = {}) => {
+    const { data, error, isLoading, mutate } = useSWR(
+        ['posts', { fetchContent }],
+        ([_, options]) => postsFetcher(options),
+        {
+            revalidateOnFocus: false,
+            dedupingInterval: 60000, // 1 minute
+        }
+    );
 
     return {
         posts: data || [],

--- a/app/search/SearchContent.jsx
+++ b/app/search/SearchContent.jsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -84,7 +84,7 @@ const saveRecentSearch = (query) => {
 
 export default function SearchPage({ isWindowMode = false }) {
     const router = useRouter();
-    const { posts, loading } = usePosts();
+    const { posts, loading } = usePosts({ fetchContent: true });
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('all');


### PR DESCRIPTION
💡 **What**: optimized the `usePosts` hook to fetch only necessary metadata columns by default, excluding the heavy `content` column. Added a `fetchContent` option to opt-in for full data when needed.

🎯 **Why**: The application was fetching the full markdown content for every post in list views (Home, Explore, Sidebar), which is unnecessary and slows down data transfer and parsing.

📊 **Impact**: significantly reduces payload size for list views. `SearchContent` (which performs client-side full-text search) continues to function correctly by explicitly requesting full content.

🔬 **Measurement**: Verify `HomeWindow` loads posts without `content` (network tab payload check), and `SearchWindow` still finds posts by content text.

---
*PR created automatically by Jules for task [4703469989943063022](https://jules.google.com/task/4703469989943063022) started by @malidk345*