### PR TITLE
⚡ Bolt: Optimize usePosts payload size

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [Supabase Partial Fetching]
+**Learning:** Supabase `select('*')` is wasteful for list views. Partial selection `select('id, title, ...')` significantly reduces payload size. SWR v2 allows passing options in array keys `['key', options]`.
+**Action:** Always check `select('*')` usages in Supabase queries and optimize for required fields only.

--- a/app/search/SearchContent.jsx
+++ b/app/search/SearchContent.jsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -79,12 +79,13 @@ const saveRecentSearch = (query) => {
         const updated = [query, ...recent].slice(0, 5);
         localStorage.setItem('recentSearches', JSON.stringify(updated));
     } catch {
+        // Ignore storage errors
     }
 };
 
 export default function SearchPage({ isWindowMode = false }) {
     const router = useRouter();
-    const { posts, loading } = usePosts();
+    const { posts, loading } = usePosts({ fetchContent: true });
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('all');


### PR DESCRIPTION
Optimizes the `usePosts` hook to fetch only necessary columns by default, significantly reducing payload size for list views. Full content is now optionally fetched only when needed (e.g., for search).

---
*PR created automatically by Jules for task [5935841513795249085](https://jules.google.com/task/5935841513795249085) started by @malidk345*