### PR TITLE
⚡ Bolt: Optimize usePosts to fetch metadata only by default

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Optimization] Reduce payload size in usePosts
+**Learning:** Fetching the full `content` column (Markdown body) for every post in the list view was a significant performance bottleneck. Defaulting to fetching only metadata columns reduces the initial load size drastically. SWR fetcher arguments can vary (array key vs spread args), so robust handling in the fetcher function is crucial.
+**Action:** Always verify if `select('*')` is necessary. Implement conditional fetching for heavy columns like `content` or `description` if they are large. Use robust argument parsing in SWR fetchers.

--- a/app/search/SearchContent.jsx
+++ b/app/search/SearchContent.jsx
@@ -84,7 +84,8 @@ const saveRecentSearch = (query) => {
 
 export default function SearchPage({ isWindowMode = false }) {
     const router = useRouter();
-    const { posts, loading } = usePosts();
+    // Search requires full content for relevance calculation
+    const { posts, loading } = usePosts({ fetchContent: true });
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('all');


### PR DESCRIPTION
⚡ Bolt: Optimize usePosts to fetch metadata only by default

💡 What: Modified `usePosts` hook to select specific metadata columns by default instead of `*` (which includes full post content). Added an option `{ fetchContent: true }` to opt-in to fetching the full content. Updated `SearchContent` to use this option.

🎯 Why: The home page and explore page were fetching the full markdown content of every post just to display a card with a title and excerpt. This resulted in unnecessary network usage and parsing overhead.

📊 Impact: Reduces the API response size for the main post list by removing the `content` field, which is typically the largest part of the data.

🔬 Measurement:
1. Load the home page. The network request to Supabase for posts should now only select `id, slug, title...` etc.
2. Go to Search. The request should include `content`.


---
*PR created automatically by Jules for task [9054368067985749351](https://jules.google.com/task/9054368067985749351) started by @malidk345*