### PR TITLE
feat: enhance writing experience for long-form content

### DIFF
--- a/components/AdminPanel/RichTextEditor.tsx
+++ b/components/AdminPanel/RichTextEditor.tsx
@@ -165,6 +165,8 @@ interface RichTextEditorProps {
     toolkitPosition?: 'header' | 'footer'
     windowKey?: string
     placeholder?: string
+    hideBorder?: boolean
+    expandHeight?: boolean
 }
 
 const RichTextEditor = ({
@@ -181,7 +183,9 @@ const RichTextEditor = ({
     extraElements = [],
     toolkitPosition = 'footer',
     windowKey,
-    placeholder
+    placeholder,
+    hideBorder = false,
+    expandHeight = false
 }: RichTextEditorProps) => {
     const { focusedWindow, isMobile } = useApp()
     const targetKey = windowKey || focusedWindow?.key
@@ -519,7 +523,7 @@ const RichTextEditor = ({
     }, [handleKeyDown])
 
     return (
-        <div className={`border border-[#1E2F46]/15 rounded-sm bg-white overflow-hidden flex flex-col ${focusMode ? 'h-screen fixed inset-0 z-[100]' : 'h-full'}`}>
+        <div className={`${hideBorder ? 'bg-transparent overflow-hidden flex flex-col' : `border border-[#1E2F46]/15 rounded-sm bg-white overflow-hidden flex flex-col`} ${focusMode ? 'h-screen fixed inset-0 z-[100]' : (expandHeight ? 'h-auto' : 'h-full')}`}>
             {/* Toolkit - injected into Window Footer or Header via portal */}
             <Toolkit
                 windowKey={windowKey || targetKey}
@@ -534,7 +538,7 @@ const RichTextEditor = ({
 
             {/* Editor */}
             <div
-                className="flex-1 overflow-auto bg-white min-h-0 cursor-text"
+                className={`${expandHeight ? 'bg-transparent cursor-text' : (hideBorder ? 'flex-1 overflow-auto bg-transparent min-h-0 cursor-text' : 'flex-1 overflow-auto bg-white min-h-0 cursor-text')}`}
                 onClick={() => editor?.chain().focus().run()}
             >
                 <EditorContent editor={editor} />

--- a/components/AppWindow/WindowRouter.tsx
+++ b/components/AppWindow/WindowRouter.tsx
@@ -504,7 +504,7 @@ function WriteRouteView({ nodeId, item, readOnly = false }: { nodeId?: string; i
             </aside>
 
             {/* Scrollable Document Area Container */}
-            <div className="flex-col relative w-full flex-1 flex min-h-0">
+            <div className="flex-col relative w-full flex-1 flex min-h-0 overflow-y-auto">
                 {/* Cover Image */}
                 {coverImage && (
                     <div className="relative w-full h-48 sm:h-64 group bg-black/5 shrink-0">
@@ -522,22 +522,24 @@ function WriteRouteView({ nodeId, item, readOnly = false }: { nodeId?: string; i
                 {/* Main Node Content Area */}
                 <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pb-20 flex-1 flex flex-col min-h-0 pt-6 gap-3">
                     {/* Title Input — framed, lowercase */}
-                    <div className="shrink-0 rounded-md border border-primary bg-primary/5 p-3">
+                    <div>
                         <input
                             type="text"
                             value={title}
                             onChange={(e) => setTitle(e.target.value)}
                             placeholder="untitled node"
-                            className="bg-transparent border-none cq-title font-extrabold tracking-tight text-primary outline-none placeholder:text-primary/10 w-full transition-all lowercase px-0"
+                            className="bg-transparent border-none font-black tracking-tight text-primary outline-none placeholder:text-primary/20 w-full transition-all lowercase px-0 text-4xl sm:text-5xl mt-6 mb-4"
                         />
                     </div>
 
                     {/* Rich Text Editor */}
-                    <div className="w-full flex-1 min-h-[400px]">
+                    <div className="w-full h-auto mb-32">
                         <RichTextEditor
                             placeholder="type here..."
                             content={content}
                             onChange={setContent}
+                            hideBorder={true}
+                            expandHeight={true}
                             toolkitPosition="header"
                             windowKey={item.key}
                             onSaveDraft={() => handleSave('draft')}
@@ -757,10 +759,10 @@ function WritePostRouteView({ postId, item }: { postId?: string, item: AppWindow
                 <div id={`window-inner-header-${item.key}`} className="pointer-events-auto" />
             </aside>
 
-            <div className="flex-col relative w-full flex-1 flex min-h-0">
+            <div className="flex-col relative w-full flex-1 flex min-h-0 overflow-y-auto">
                 <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pb-20 flex-1 flex flex-col min-h-0 pt-6 gap-3">
                     {/* Title Input — framed, lowercase */}
-                    <div className="shrink-0 rounded-md border border-primary bg-primary/5 p-3">
+                    <div>
                         <input
                             type="text"
                             value={title}
@@ -769,15 +771,24 @@ function WritePostRouteView({ postId, item }: { postId?: string, item: AppWindow
                                 if (!currentPostId) setSlug(toSlug(e.target.value))
                             }}
                             placeholder="untitled post"
-                            className="bg-transparent border-none cq-title font-extrabold tracking-tight text-primary outline-none placeholder:text-primary/10 w-full transition-all lowercase px-0"
+                            className="bg-transparent border-none font-black tracking-tight text-primary outline-none placeholder:text-primary/20 w-full transition-all lowercase px-0 text-4xl sm:text-5xl mt-6 mb-4"
+                        />
+                        <textarea
+                            value={excerpt}
+                            onChange={(e) => setExcerpt(e.target.value)}
+                            placeholder="brief excerpt or subtitle..."
+                            className="bg-transparent border-none text-primary/60 outline-none w-full resize-none text-lg leading-relaxed mb-6 px-0"
+                            rows={2}
                         />
                     </div>
 
-                    <div className="w-full flex-1 min-h-[400px]">
+                    <div className="w-full h-auto mb-32">
                         <RichTextEditor
                             placeholder="type here..."
                             content={content}
                             onChange={setContent}
+                            hideBorder={true}
+                            expandHeight={true}
                             toolkitPosition="header"
                             windowKey={item.key}
                             onSaveDraft={() => handleSavePost(false)}


### PR DESCRIPTION
The user requested an improved, mobile-friendly, and aesthetically advanced writing interface for long texts that aligns with the site's overall design.

This PR overhauls the writing experience by transforming the confined node/post editor into a seamless, auto-expanding layout (similar to Notion or Medium). 
- Modifies `RichTextEditor.tsx` to conditionally accept `hideBorder` and `expandHeight` props, allowing the editor to adapt to its parent container dynamically.
- Updates `WritePostRouteView` and `WriteRouteView` inside `components/AppWindow/WindowRouter.tsx` to use `overflow-y-auto` natively on the page.
- Redesigns title inputs to be borderless and dramatically larger, creating a premium visual hierarchy.
- Replaces rigid `min-h-[400px]` containers with auto-expanding wrappers equipped with bottom padding (`mb-32`), ensuring the mobile keyboard never obscures the cursor.

---
*PR created automatically by Jules for task [4949333209093910887](https://jules.google.com/task/4949333209093910887) started by @malidk345*