### PR TITLE
feat: server-side fetching and ISR for posts

### DIFF
--- a/app/posts/[slug]/page-client.tsx
+++ b/app/posts/[slug]/page-client.tsx
@@ -1,7 +1,9 @@
 "use client"
 import Wrapper from "components/Wrapper";
 
-export default function PostPageClient() {
+export default function PostPageClient({ initialPost }: { initialPost?: any }) {
+    // Note: We'll eventually hydrate the window state with initialPost 
+    // to ensure the Blog view opens immediately with pre-fetched data.
     return (
         <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { ArticleJsonLd } from "components/SEO/JsonLd";
+import PostPageClient from "./page-client";
 
-export const runtime = 'edge';
+// ISR: Revalidate every hour
+export const revalidate = 3600;
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://worldinmaking.com";
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
@@ -11,7 +13,7 @@ async function getPost(slug: string) {
   if (!supabaseUrl || !supabaseKey || !slug) return null;
 
   const url = new URL("/rest/v1/posts", supabaseUrl);
-  url.searchParams.set("select", "title,slug,excerpt,content,image_url,author,author_avatar,category,tags,created_at,updated_at,language,translations");
+  url.searchParams.set("select", "id,title,slug,excerpt,content,image_url,author,author_avatar,category,tags,created_at,updated_at,language,translations");
   url.searchParams.set("published", "eq.true");
   url.searchParams.set("or", `(slug.eq.${slug},translations->en->>slug.eq.${slug},translations->tr->>slug.eq.${slug},translations->de->>slug.eq.${slug},translations->es->>slug.eq.${slug})`);
   url.searchParams.set("limit", "1");
@@ -22,6 +24,7 @@ async function getPost(slug: string) {
         apikey: supabaseKey,
         Authorization: `Bearer ${supabaseKey}`,
       },
+      // ISR handled at file level but kept here for safety
       next: { revalidate: 3600 },
     });
 
@@ -47,6 +50,28 @@ async function getPost(slug: string) {
     return postData;
   } catch {
     return null;
+  }
+}
+
+/** Pre-render popular/recent paths */
+export async function generateStaticParams() {
+  if (!supabaseUrl || !supabaseKey) return [];
+  
+  const url = new URL("/rest/v1/posts", supabaseUrl);
+  url.searchParams.set("select", "slug");
+  url.searchParams.set("published", "eq.true");
+  url.searchParams.set("limit", "100");
+  url.searchParams.set("order", "created_at.desc");
+
+  try {
+    const res = await fetch(url.toString(), {
+      headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+    });
+    if (!res.ok) return [];
+    const posts = await res.json();
+    return posts.map((post: { slug: string }) => ({ slug: post.slug }));
+  } catch {
+    return [];
   }
 }
 
@@ -135,8 +160,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-import PostPageClient from "./page-client";
-
 export default async function PostPage({ params }: Props) {
   const { slug } = await params;
   const post = await getPost(slug);
@@ -151,6 +174,15 @@ export default async function PostPage({ params }: Props) {
   const authorName = post.author || "World in Making";
   const keywords = post.tags ? (Array.isArray(post.tags) ? post.tags : post.tags.split(",")) : [];
 
+  // Data for client-side to avoid another fetch
+  const adaptedPost = {
+    ...post,
+    date: post.created_at,
+    image: post.image_url,
+    authors: [{ name: authorName, avatar: post.author_avatar, username: authorName }],
+    headings: [], // Headings will be calculated on client for TOC
+  };
+
   return (
     <>
       <ArticleJsonLd
@@ -163,7 +195,7 @@ export default async function PostPage({ params }: Props) {
         authorName={authorName}
         keywords={keywords}
       />
-      <PostPageClient />
+      <PostPageClient initialPost={adaptedPost} />
     </>
   );
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { ArticleJsonLd } from "components/SEO/JsonLd";
 import PostPageClient from "./page-client";
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+import html from 'remark-html';
 
 // ISR: Revalidate every hour
 export const revalidate = 3600;
@@ -8,6 +11,14 @@ export const revalidate = 3600;
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://worldinmaking.com";
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
+
+async function parseMarkdown(content: string) {
+  const result = await remark()
+    .use(remarkGfm)
+    .use(html, { sanitize: false }) // Sanitization handled by rehype-sanitize if needed, but we trust Supabase content for now to preserve specific HTML
+    .process(content);
+  return result.toString();
+}
 
 async function getPost(slug: string) {
   if (!supabaseUrl || !supabaseKey || !slug) return null;
@@ -24,7 +35,6 @@ async function getPost(slug: string) {
         apikey: supabaseKey,
         Authorization: `Bearer ${supabaseKey}`,
       },
-      // ISR handled at file level but kept here for safety
       next: { revalidate: 3600 },
     });
 
@@ -47,13 +57,18 @@ async function getPost(slug: string) {
         }
       }
     }
+    
+    if (postData?.content) {
+      // Pre-parse markdown on the server
+      postData.htmlContent = await parseMarkdown(postData.content);
+    }
+    
     return postData;
   } catch {
     return null;
   }
 }
 
-/** Pre-render popular/recent paths */
 export async function generateStaticParams() {
   if (!supabaseUrl || !supabaseKey) return [];
   
@@ -75,8 +90,8 @@ export async function generateStaticParams() {
   }
 }
 
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+function stripHtml(htmlStr: string): string {
+  return htmlStr.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
 }
 
 interface Post {
@@ -174,13 +189,12 @@ export default async function PostPage({ params }: Props) {
   const authorName = post.author || "World in Making";
   const keywords = post.tags ? (Array.isArray(post.tags) ? post.tags : post.tags.split(",")) : [];
 
-  // Data for client-side to avoid another fetch
   const adaptedPost = {
     ...post,
     date: post.created_at,
     image: post.image_url,
     authors: [{ name: authorName, avatar: post.author_avatar, username: authorName }],
-    headings: [], // Headings will be calculated on client for TOC
+    headings: [],
   };
 
   return (

--- a/components/ReaderView/BlogPostView.tsx
+++ b/components/ReaderView/BlogPostView.tsx
@@ -22,9 +22,10 @@ interface BlogPostViewProps {
         authors?: { name: string, avatar: string, username?: string }[]
         image: string | null
         content: string
+        htmlContent?: string // Added for server-rendered HTML
         tags?: string[]
         headings: { id: string, text: string, level: number }[]
-        translations?: Record<string, { title: string, content: string, excerpt?: string, slug?: string }>
+        translations?: Record<string, { title: string, content: string, excerpt?: string, slug?: string, htmlContent?: string }>
         language?: string
         originalLanguage?: string
         description?: string
@@ -75,8 +76,10 @@ const BlogPostInner = React.memo(({ post }: BlogPostViewProps) => {
 
     const title = (!isOriginal && translation?.title) ? translation.title : post.title
     const content = (!isOriginal && translation?.content) ? translation.content : post.content
+    const serverHtml = (!isOriginal && translation?.htmlContent) ? translation.htmlContent : (isOriginal ? post.htmlContent : null)
+    
     const description = (!isOriginal && translation?.excerpt) ? translation.excerpt : (post.description || post.content.slice(0, 160))
-    const isRichTextHtml = useMemo(() => /<\/?[a-z][\s\S]*>/i.test(content || ''), [content])
+    const isRichTextHtml = useMemo(() => serverHtml || /<\/?[a-z][\s\S]*>/i.test(content || ''), [content, serverHtml])
 
     const body = useMemo(() => {
         const wordCount = content ? content.split(/\s+/).filter(Boolean).length : 0;
@@ -103,11 +106,12 @@ const BlogPostInner = React.memo(({ post }: BlogPostViewProps) => {
 
     // Normalize HTML content and inject IDs into headings for TOC linking
     const processedContent = useMemo(() => {
-        if (typeof window === 'undefined') return content;
+        const sourceContent = serverHtml || content;
+        if (typeof window === 'undefined') return sourceContent;
 
         try {
             const parser = new DOMParser()
-            const doc = parser.parseFromString(content, 'text/html')
+            const doc = parser.parseFromString(sourceContent, 'text/html')
 
             doc.querySelectorAll('h1, h2, h3, h4').forEach((heading) => {
                 if (heading.id) return
@@ -153,9 +157,9 @@ const BlogPostInner = React.memo(({ post }: BlogPostViewProps) => {
 
             return doc.body.innerHTML
         } catch {
-            return content
+            return sourceContent
         }
-    }, [content]);
+    }, [content, serverHtml]);
 
     const sanitizedProcessedContent = useMemo(() => sanitizeHtml(processedContent), [processedContent])
 


### PR DESCRIPTION
This PR implements server-side fetching and Incremental Static Regeneration (ISR) for the post routes.

### Changes:
- Added `generateStaticParams` to `app/posts/[slug]/page.tsx` to pre-render the top 100 posts at build time.
- Set `export const revalidate = 3600` for 1-hour ISR.
- Optimized the server component to fetch full post data from Supabase, including translations.
- Prepared `PostPageClient` to receive `initialPost` data to avoid redundant client-side fetching (hydration pending).
- Improved SEO by ensuring post metadata is fully populated on the server.

Next steps: Implement server-side markdown parsing using unified/remark in the server component.