### PR TITLE
feat: hierarchical blueprints format with custom HTML/CSS canvas

### DIFF
--- a/components/AppWindow/WindowRouter.tsx
+++ b/components/AppWindow/WindowRouter.tsx
@@ -22,6 +22,8 @@ import { Share, Image as ImageIcon, Palette, Hash, CheckCircle, ChevronDown, Fil
 import OSButton from 'components/OSButton'
 import { Popover } from 'components/RadixUI/Popover'
 import { sanitizeHtml, toSlug } from '../../utils/security'
+import BlueprintsExplorer from 'components/Blueprints/BlueprintsExplorer'
+import BlueprintPostView from 'components/Blueprints/BlueprintPostView'
 
 interface AdaptablePost {
     id: number | string
@@ -99,6 +101,17 @@ function WindowRouterInner({ item }: { item: AppWindow }) {
     const blogMatch = path.match(/^\/(blog|posts)\/([^/]+)/)
     if (blogMatch) {
         return <BlogRouteView slug={blogMatch[2]} />
+    }
+
+    // /blueprints
+    if (path === '/blueprints') {
+        return <BlueprintsExplorer />
+    }
+
+    // /blueprints/post/:slug
+    const blueprintMatch = path.match(/^\/blueprints\/post\/([^/]+)/)
+    if (blueprintMatch) {
+        return <BlueprintPostView slug={blueprintMatch[1]} />
     }
 
     // /search

--- a/components/Blueprints/BlueprintPostView.tsx
+++ b/components/Blueprints/BlueprintPostView.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import React, { useEffect, useState } from 'react'
+import { useBlueprints, BlueprintPost } from 'hooks/useBlueprints'
+import Loading from 'components/Loading'
+import { sanitizeHtml } from 'utils/security'
+
+export default function BlueprintPostView({ slug }: { slug: string }) {
+    const { getPostBySlug } = useBlueprints()
+    const [post, setPost] = useState<any>(null)
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        getPostBySlug(slug).then(data => {
+            setPost(data)
+            setLoading(false)
+        })
+    }, [slug, getPostBySlug])
+
+    if (loading) return <Loading fullScreen label="loading technical layout" />
+    if (!post) return <div className="p-8 text-center lowercase">blueprint not found</div>
+
+    return (
+        <div className="absolute inset-0 overflow-auto bg-white dark:bg-black">
+            {post.custom_css && (
+                <style dangerouslySetInnerHTML={{ __html: post.custom_css }} />
+            )}
+            
+            <div className="blueprint-canvas h-full w-full">
+                {post.content_html ? (
+                    <div 
+                        className="w-full h-full"
+                        dangerouslySetInnerHTML={{ __html: sanitizeHtml(post.content_html) }} 
+                    />
+                ) : (
+                    <div className="prose prose-sm max-w-none p-12">
+                        {post.content_markdown}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/components/Blueprints/BlueprintsExplorer.tsx
+++ b/components/Blueprints/BlueprintsExplorer.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import React, { useEffect, useState } from 'react'
+import { useBlueprints, BlueprintCategory, BlueprintLecture, BlueprintPost } from 'hooks/useBlueprints'
+import ScrollArea from 'components/RadixUI/ScrollArea'
+import Loading from 'components/Loading'
+import { useApp } from 'context/App'
+import { ChevronRight, BookOpen, Layers } from 'lucide-react'
+
+export default function BlueprintsExplorer() {
+    const { fetchHierarchy } = useBlueprints()
+    const { addWindow } = useApp()
+    const [hierarchy, setHierarchy] = useState<any[]>([])
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        fetchHierarchy().then(data => {
+            setHierarchy(data || [])
+            setLoading(false)
+        })
+    }, [fetchHierarchy])
+
+    const handlePostClick = (post: BlueprintPost) => {
+        addWindow({
+            key: `blueprint-post-${post.id}`,
+            path: `/blueprints/post/${post.slug}`,
+            title: `blueprint: ${post.title.toLowerCase()}`,
+        })
+    }
+
+    if (loading) return <Loading fullScreen label="scanning blueprints" />
+
+    return (
+        <div className="absolute inset-0 bg-primary flex flex-col font-mono lowercase">
+            <ScrollArea>
+                <div className="max-w-4xl mx-auto py-12 px-6">
+                    <header className="mb-12 border-b border-primary/10 pb-6">
+                        <h1 className="text-2xl font-black flex items-center gap-3">
+                            <Layers className="size-6" /> blueprints
+                        </h1>
+                        <p className="opacity-50 mt-2 text-xs">structured knowledge / technical archives</p>
+                    </header>
+
+                    <div className="space-y-12">
+                        {hierarchy.map((category) => (
+                            <section key={category.id} className="blueprint-category">
+                                <h2 className="text-xs font-black tracking-widest uppercase opacity-30 mb-6 border-l-2 border-primary pl-4">
+                                    {category.name}
+                                </h2>
+                                
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                    {category.lectures?.map((lecture: any) => (
+                                        <div key={lecture.id} className="bg-accent/50 border border-primary/10 rounded-sm p-4 hover:border-primary/30 transition-colors">
+                                            <h3 className="text-sm font-bold flex items-center gap-2 mb-3">
+                                                <BookOpen className="size-4 opacity-50" /> {lecture.name}
+                                            </h3>
+                                            
+                                            <ul className="space-y-1 ml-6">
+                                                {lecture.posts?.map((post: BlueprintPost) => (
+                                                    <li 
+                                                        key={post.id}
+                                                        onClick={() => handlePostClick(post)}
+                                                        className="text-[11px] opacity-60 hover:opacity-100 hover:text-blue-500 cursor-pointer flex items-center gap-1 group"
+                                                    >
+                                                        <ChevronRight className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                                                        {post.title}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    ))}
+                                </div>
+                            </section>
+                        ))}
+                    </div>
+                </div>
+            </ScrollArea>
+        </div>
+    )
+}

--- a/hooks/useBlueprints.ts
+++ b/hooks/useBlueprints.ts
@@ -1,0 +1,64 @@
+import { supabase } from '../lib/supabase';
+
+export interface BlueprintCategory {
+    id: string;
+    name: string;
+    slug: string;
+    description?: string;
+    order_index: number;
+}
+
+export interface BlueprintLecture {
+    id: string;
+    category_id: string;
+    name: string;
+    slug: string;
+    description?: string;
+    order_index: number;
+}
+
+export interface BlueprintPost {
+    id: string;
+    lecture_id: string;
+    title: string;
+    slug: string;
+    content_html?: string;
+    content_markdown?: string;
+    custom_css?: string;
+    is_published: boolean;
+    order_index: number;
+}
+
+export const useBlueprints = () => {
+    const fetchHierarchy = async () => {
+        const { data: categories } = await supabase
+            .from('blueprint_categories')
+            .select(`
+                *,
+                lectures:blueprint_lectures (
+                    *,
+                    posts:blueprint_posts (*)
+                )
+            `)
+            .order('order_index', { ascending: true });
+        
+        return categories;
+    };
+
+    const getPostBySlug = async (slug: string) => {
+        const { data } = await supabase
+            .from('blueprint_posts')
+            .select(`
+                *,
+                lecture:blueprint_lectures (
+                    *,
+                    category:blueprint_categories (*)
+                )
+            `)
+            .eq('slug', slug)
+            .single();
+        return data;
+    };
+
+    return { fetchHierarchy, getPostBySlug };
+};

--- a/supabase/migrations/20260630000000_create_blueprints_hierarchy.sql
+++ b/supabase/migrations/20260630000000_create_blueprints_hierarchy.sql
@@ -1,0 +1,44 @@
+-- 1. Blueprint Categories
+CREATE TABLE public.blueprint_categories (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    description TEXT,
+    order_index INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- 2. Blueprint Lectures (belonging to Categories)
+CREATE TABLE public.blueprint_lectures (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    category_id UUID REFERENCES public.blueprint_categories(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    description TEXT,
+    order_index INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- 3. Blueprint Posts (the actual HTML/Markdown content)
+CREATE TABLE public.blueprint_posts (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    lecture_id UUID REFERENCES public.blueprint_lectures(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    content_html TEXT,
+    content_markdown TEXT,
+    custom_css TEXT,
+    is_published BOOLEAN DEFAULT false,
+    order_index INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Enable RLS
+ALTER TABLE public.blueprint_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.blueprint_lectures ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.blueprint_posts ENABLE ROW LEVEL SECURITY;
+
+-- Public read access
+CREATE POLICY "Allow public read for categories" ON public.blueprint_categories FOR SELECT USING (true);
+CREATE POLICY "Allow public read for lectures" ON public.blueprint_lectures FOR SELECT USING (true);
+CREATE POLICY "Allow public read for posts" ON public.blueprint_posts FOR SELECT USING (true);


### PR DESCRIPTION
This PR implements the hierarchical "Blueprints" format as requested.

### Key Changes:
- **Database Schema**: Added `blueprint_categories`, `blueprint_lectures`, and `blueprint_posts` tables with relational hierarchy and RLS policies.
- **Hook**: Implemented `useBlueprints` for fetching the nested hierarchy and individual blueprint posts.
- **Explorer UI**: Created `BlueprintsExplorer` to navigate Categories -> Lectures -> Posts.
- **Canvas View**: Created `BlueprintPostView` for rendering custom HTML/CSS layouts within the site's window system.
- **Routing**: Updated `WindowRouter` to handle new blueprint paths.

This architecture supports "class/course" style structured content with full design freedom for individual posts.