### PR TITLE
feat: iOS 26 aesthetic update for window system

### DIFF
--- a/components/AppWindow/WindowRouter.tsx
+++ b/components/AppWindow/WindowRouter.tsx
@@ -428,7 +428,7 @@ function WriteRouteView({ nodeId, item, readOnly = false }: { nodeId?: string; i
     }
 
     const themeClasses = {
-        'default': 'bg-[#fafcfc] dark:bg-primary/5',
+        'default': 'bg-white dark:bg-white',
         'yellow': 'bg-amber-50 dark:bg-amber-950/20',
         'green': 'bg-emerald-50 dark:bg-emerald-950/20',
         'blue': 'bg-sky-50 dark:bg-sky-950/20',
@@ -767,7 +767,7 @@ function WritePostRouteView({ postId, item }: { postId?: string, item: AppWindow
     }
 
     return (
-        <div className="flex flex-col size-full overflow-hidden text-black bg-[#fafcfc] dark:bg-primary/5 transition-colors duration-500">
+        <div className="flex flex-col size-full overflow-hidden text-black bg-white dark:bg-white transition-colors duration-500">
             <aside className="sticky top-0 z-50 shrink-0">
                 <div id={`window-inner-header-${item.key}`} className="pointer-events-auto" />
             </aside>

--- a/components/AppWindow/index.tsx
+++ b/components/AppWindow/index.tsx
@@ -414,8 +414,8 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             ref={windowRef}
                             data-app="AppWindow"
                             data-scheme="tertiary"
-                            className={`group @container absolute !select-auto flex flex-col bg-[rgba(var(--bg),0.65)] backdrop-blur-3xl ${isFocused ? 'shadow-[0_20px_60px_-15px_rgba(0,0,0,0.2)] border-black/5 dark:border-white/10 ring-1 ring-black/5 dark:ring-white/10' : 'shadow-lg border-input'
-                                } ${dragging ? '[&_*]:select-none' : ''} ${item.minimal ? '!shadow-none' : (isMaximized ? 'rounded-none border-b border-primary' : 'border rounded-2xl')} ${chrome ? 'overflow-hidden' : ''}`}
+                            className={`group @container absolute !select-auto flex flex-col glass-card ${isFocused ? 'shadow-[0_20px_60px_-15px_rgba(0,0,0,0.2)] border-black/5 dark:border-white/10 ring-1 ring-black/5 dark:ring-white/10' : 'shadow-lg border-primary'
+                                } ${dragging ? '[&_*]:select-none' : ''} ${item.minimal ? '!shadow-none' : (isMaximized ? 'rounded-none border-b border-primary' : 'border rounded-[22px]')} ${chrome ? 'overflow-hidden' : ''}`}
                             style={{ zIndex: item.zIndex, rotateX: tiltX, rotateY: tiltY, transformPerspective: 1200 }}
                             initial={{
                                 scale: 0.08,
@@ -654,14 +654,14 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             )}
 
                             {/* Spotlight effect layered over window */}
-                            <div className="pointer-events-none absolute inset-0 z-50 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+                            <div className="pointer-events-none absolute inset-0 z-50 rounded-[22px] opacity-0 group-hover:opacity-100 transition-opacity duration-500"
                                  style={{
                                     background: `radial-gradient(800px circle at var(--mouse-x) var(--mouse-y), rgba(255,255,255,0.06), transparent 40%)`, backgroundAttachment: "fixed"
                                  }}
                             />
 
                             <div className="w-full flex-1 flex flex-col bg-transparent min-h-0 relative px-1.5 has-[+div:empty]:pb-1.5">
-                                <div className="w-full h-full bg-primary flex-1 overflow-hidden relative shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.05)] border border-black/10 dark:border-white/10 rounded-xl">
+                                <div className="w-full h-full bg-white flex-1 overflow-hidden relative shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.05)] border border-black/10 dark:border-white/10 rounded-[18px]">
                                     {(!animating || rendered) && (
                                         item.key === 'home' ? <HomeControl /> : <WindowRouter item={item} />
                                     )}


### PR DESCRIPTION
This PR introduces aesthetic updates to the floating window system to align with an "iOS 26" inspired visual style. 

The primary changes are:
1. Softer, more rounded corners for the outer application window (`rounded-[22px]`).
2. Adoption of the site's global `glass-card` class for a more sophisticated blur and dynamic spotlight hover effect.
3. Explicitly setting the inner content area of the windows to render with a solid white background, regardless of the active theme, to provide a clean reading and interaction canvas.
4. Adjusting the inner boundary border radius (`rounded-[18px]`) to perfectly nest within the updated outer bounds.

---
*PR created automatically by Jules for task [17472480224223281751](https://jules.google.com/task/17472480224223281751) started by @malidk345*