### PR TITLE
feat: implement Spatial UI/iOS 26 styling enhancements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -163,14 +163,15 @@ mark {
   }
 
   .glass-card {
-    background: rgba(var(--bg-rgb), 0.5);
-    backdrop-filter: blur(40px) saturate(200%);
-    -webkit-backdrop-filter: blur(40px) saturate(200%);
+    background: rgba(var(--bg-rgb), 0.6);
+    backdrop-filter: blur(60px) saturate(200%);
+    -webkit-backdrop-filter: blur(60px) saturate(200%);
     border: 1px solid rgba(var(--primary-rgb), 0.05);
     box-shadow:
-      inset 0 1px 0 0 rgba(255, 255, 255, 0.1),
-      inset 0 0 0 1px rgba(255, 255, 255, 0.02),
-      0 10px 40px -10px rgba(0, 0, 0, 0.15);
+      inset 0 1px 0 0 rgba(255, 255, 255, 0.2),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+      0 20px 60px -10px rgba(0, 0, 0, 0.25),
+      0 40px 100px -20px rgba(0, 0, 0, 0.15);
     /* Dynamic hover light based on mouse position */
     background-image: radial-gradient(
       600px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
@@ -772,8 +773,8 @@ mark {
   h5,
   h6 {
     @apply font-bold;
-    letter-spacing: -0.015rem;
-    font-variation-settings: 'wght' 800;
+    letter-spacing: -0.025em;
+    font-variation-settings: 'wght' 700;
     font-family: var(--font-ibm-plex), -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'segoe ui', 'helvetica neue', helvetica, Ubuntu, roboto, noto, arial, sans-serif !important;
   }
 

--- a/components/AppWindow/index.tsx
+++ b/components/AppWindow/index.tsx
@@ -43,10 +43,10 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
     const motionY = useMotionValue(0);
     const xVelocity = useVelocity(motionX);
     const yVelocity = useVelocity(motionY);
-    const smoothXVelocity = useSpring(xVelocity, { damping: 50, stiffness: 400 });
-    const smoothYVelocity = useSpring(yVelocity, { damping: 50, stiffness: 400 });
-    const tiltX = useTransform(smoothYVelocity, [-1000, 1000], [5, -5]); // Pitch
-    const tiltY = useTransform(smoothXVelocity, [-1000, 1000], [-5, 5]); // Yaw
+    const smoothXVelocity = useSpring(xVelocity, { damping: 40, stiffness: 300 });
+    const smoothYVelocity = useSpring(yVelocity, { damping: 40, stiffness: 300 });
+    const tiltX = useTransform(smoothYVelocity, [-1000, 1000], [8, -8]); // Pitch
+    const tiltY = useTransform(smoothXVelocity, [-1000, 1000], [-8, 8]); // Yaw
 
     const {
         minimizeWindow,
@@ -415,7 +415,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             data-app="AppWindow"
                             data-scheme="tertiary"
                             className={`group @container absolute !select-auto flex flex-col glass-card ${isFocused ? 'shadow-[0_20px_60px_-15px_rgba(0,0,0,0.2)] border-black/5 dark:border-white/10 ring-1 ring-black/5 dark:ring-white/10' : 'shadow-lg border-primary'
-                                } ${dragging ? '[&_*]:select-none' : ''} ${item.minimal ? '!shadow-none' : (isMaximized ? 'rounded-none border-b border-primary' : 'border rounded-[22px]')} ${chrome ? 'overflow-hidden' : ''}`}
+                                } ${dragging ? '[&_*]:select-none' : ''} ${item.minimal ? '!shadow-none' : (isMaximized ? 'rounded-none border-b border-primary' : 'border rounded-[32px]')} ${chrome ? 'overflow-hidden' : ''}`}
                             style={{ zIndex: item.zIndex, rotateX: tiltX, rotateY: tiltY, transformPerspective: 1200 }}
                             initial={{
                                 scale: 0.08,
@@ -654,14 +654,14 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             )}
 
                             {/* Spotlight effect layered over window */}
-                            <div className="pointer-events-none absolute inset-0 z-50 rounded-[22px] opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+                            <div className="pointer-events-none absolute inset-0 z-50 rounded-[32px] opacity-0 group-hover:opacity-100 transition-opacity duration-500"
                                  style={{
                                     background: `radial-gradient(800px circle at var(--mouse-x) var(--mouse-y), rgba(255,255,255,0.06), transparent 40%)`, backgroundAttachment: "fixed"
                                  }}
                             />
 
                             <div className="w-full flex-1 flex flex-col bg-transparent min-h-0 relative px-1.5 has-[+div:empty]:pb-1.5">
-                                <div className="w-full h-full bg-white flex-1 overflow-hidden relative shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.05)] border border-black/10 dark:border-white/10 rounded-[18px]">
+                                <div className="w-full h-full bg-white/80 dark:bg-accent-dark/80 backdrop-blur-3xl-safe flex-1 overflow-hidden relative shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.05)] border border-black/10 dark:border-white/10 rounded-[28px]">
                                     {(!animating || rendered) && (
                                         item.key === 'home' ? <HomeControl /> : <WindowRouter item={item} />
                                     )}

--- a/components/AppWindow/index.tsx
+++ b/components/AppWindow/index.tsx
@@ -661,7 +661,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                             />
 
                             <div className="w-full flex-1 flex flex-col bg-transparent min-h-0 relative px-1.5 has-[+div:empty]:pb-1.5">
-                                <div className="w-full h-full bg-white/80 dark:bg-accent-dark/80 backdrop-blur-3xl-safe flex-1 overflow-hidden relative shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.05)] border border-black/10 dark:border-white/10 rounded-[28px]">
+                                <div className="w-full h-full bg-white/80 dark:bg-accent-dark/80 backdrop-blur-3xl-safe flex-1 overflow-hidden relative shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.05)] border border-black/10 dark:border-white/10 rounded-[18px]">
                                     {(!animating || rendered) && (
                                         item.key === 'home' ? <HomeControl /> : <WindowRouter item={item} />
                                     )}

--- a/components/OSButton/index.tsx
+++ b/components/OSButton/index.tsx
@@ -57,22 +57,22 @@ const OSButton = React.memo(React.forwardRef<HTMLButtonElement | HTMLAnchorEleme
         ref
     ) => {
         const baseClasses =
-            'relative items-center rounded border text-primary transition-colors transition-[font-size,line-height,padding] transition-50 hover:transition-none disabled:text-muted disabled:cursor-not-allowed select-none'
+            'relative items-center rounded-full border text-primary transition-colors transition-[font-size,line-height,padding] transition-50 hover:transition-none disabled:text-muted disabled:cursor-not-allowed select-none'
 
         const parentSizeClasses = {
-            xs: 'border-px top-[0px] rounded-[5px]',
-            sm: 'border-[1.5px] top-[0px] rounded-[5px]',
-            md: 'border-[1.5px] top-[0px] rounded-[6px]',
-            lg: 'border-[1.5px] top-[0px] rounded-[6px]',
-            xl: 'border-[1.5px] top-[0px] rounded-[6px]',
+            xs: 'border-px top-[0px] rounded-full',
+            sm: 'border-[1.5px] top-[0px] rounded-full',
+            md: 'border-[1.5px] top-[0px] rounded-full',
+            lg: 'border-[1.5px] top-[0px] rounded-full',
+            xl: 'border-[1.5px] top-[0px] rounded-full',
         }
 
         const childSizeClasses = {
-            xs: 'px-1.5 py-0.5 text-[11px] gap-0.5 rounded-[5px] translate-y-[-1px] hover:translate-y-[-2px] active:translate-y-[0px] border-[1.5px] -mx-px group-disabled:hover:!translate-y-[-1px]',
-            sm: 'px-2 py-0.5 text-xs gap-1 rounded-[5px] translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
-            md: 'px-2.5 py-1 gap-1 rounded-[6px] text-[13px] translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
-            lg: 'px-3 py-1.5 text-[15px] gap-1 rounded-[6px] translate-y-[-2px] hover:translate-y-[-4px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
-            xl: 'px-4 py-2 text-base gap-1.5 rounded-[6px] translate-y-[-2px] hover:translate-y-[-4px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
+            xs: 'px-1.5 py-0.5 text-[11px] gap-0.5 rounded-full translate-y-[-1px] hover:translate-y-[-2px] active:translate-y-[0px] border-[1.5px] -mx-px group-disabled:hover:!translate-y-[-1px]',
+            sm: 'px-2 py-0.5 text-xs gap-1 rounded-full translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
+            md: 'px-2.5 py-1 gap-1 rounded-full text-[13px] translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
+            lg: 'px-3 py-1.5 text-[15px] gap-1 rounded-full translate-y-[-2px] hover:translate-y-[-4px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
+            xl: 'px-4 py-2 text-base gap-1.5 rounded-full translate-y-[-2px] hover:translate-y-[-4px] active:translate-y-[0px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px]',
         }
 
         const simpleSizeClasses = {

--- a/components/Wrapper/index.tsx
+++ b/components/Wrapper/index.tsx
@@ -71,8 +71,8 @@ export default function Wrapper() {
                                             z: 0,
                                             transition: {
                                                 type: "spring",
-                                                stiffness: 300,
-                                                damping: 25,
+                                                stiffness: 200,
+                                                damping: 20,
                                                 mass: 1,
                                                 restDelta: 0.001
                                             }
@@ -85,8 +85,8 @@ export default function Wrapper() {
                                     transition: {
                                         delay: index * 0.05,
                                         type: "spring",
-                                        stiffness: 300,
-                                        damping: 30,
+                                        stiffness: 200,
+                                        damping: 25,
                                         duration: 0.4
                                     },
                                 }}


### PR DESCRIPTION
This pull request updates the global windowing and component style to closely match a future-forward "iOS 26" or "Spatial UI" design language. Changes include increased border radii (up to 32px), heavier backdrop-blurs, spatial box-shadows, and refined Framer Motion spring physics for softer, fluid interactions.

---
*PR created automatically by Jules for task [5754758217852702116](https://jules.google.com/task/5754758217852702116) started by @malidk345*