### PR TITLE
Improve window opening animations and mobile window sizing

### DIFF
--- a/components/AppWindow/index.tsx
+++ b/components/AppWindow/index.tsx
@@ -91,7 +91,6 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
     const [resizing, setResizing] = useState(false)
     const [localSize, setLocalSize] = useState(item.size)
     const [localPos, setLocalPos] = useState(item.position)
-    const hasMobileAdjusted = useRef(false)
 
     useEffect(() => {
         if (windowRef.current) {
@@ -316,26 +315,6 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
         }
     }, [item, history, activeHistoryIndex])
 
-    useEffect(() => {
-        if (typeof window === 'undefined') return
-        if (hasMobileAdjusted.current) return
-
-        const isMobile = window.innerWidth <= 768
-        if (!isMobile) return
-
-        if (!constraintsRef.current) return
-        const bounds = constraintsRef.current.getBoundingClientRect()
-        const inset = 0
-        const nextSize = {
-            width: bounds.width - inset * 2,
-            height: bounds.height - inset * 2,
-        }
-        const nextPosition = { x: inset, y: inset }
-
-        hasMobileAdjusted.current = true
-        updateWindow(item, { size: nextSize, position: nextPosition })
-    }, [item, constraintsRef, updateWindow])
-
     const isMaximized = useMemo(() => {
         if (!constraintsRef.current) return false
         const bounds = constraintsRef.current.getBoundingClientRect()
@@ -437,35 +416,55 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                 x: windowPosition.x,
                                 y: windowPosition.y,
                                 transition: {
-                                    scale: { duration: 0.23, ease: [0.2, 0.2, 0.8, 1] },
-                                    x: { duration: 0.23, ease: [0.2, 0.2, 0.8, 1] },
-                                    y: { duration: 0.23, ease: [0.2, 0.2, 0.8, 1] },
+                                    type: "spring",
+                                    stiffness: 350,
+                                    damping: 25,
+                                    mass: 0.8
                                 }
                             }}
-                            transition={{
-                                duration: siteSettings.performanceBoost ? 0 : 0.2,
-                                scale: {
-                                    duration: siteSettings.performanceBoost ? 0 : 0.2,
-                                    delay: siteSettings.performanceBoost ? 0 : 0.1,
-                                    ease: [0.2, 0.2, 0.8, 1],
-                                },
-                                width: {
-                                    duration: (dragging || siteSettings.performanceBoost) ? 0 : 0.18,
-                                    ease: [0.2, 0.2, 0.8, 1],
-                                },
-                                height: {
-                                    duration: (dragging || siteSettings.performanceBoost) ? 0 : 0.18,
-                                    ease: [0.2, 0.2, 0.8, 1],
-                                },
-                                x: {
-                                    duration: (dragging || siteSettings.performanceBoost) ? 0 : 0.18,
-                                    ease: [0.2, 0.2, 0.8, 1],
-                                },
-                                y: {
-                                    duration: (dragging || siteSettings.performanceBoost) ? 0 : 0.18,
-                                    ease: [0.2, 0.2, 0.8, 1],
-                                },
-                            }}
+                            transition={
+                                siteSettings.performanceBoost ? { duration: 0 } : {
+                                    type: "spring",
+                                    stiffness: 350,
+                                    damping: 25,
+                                    mass: 0.8,
+                                    scale: {
+                                        type: "spring",
+                                        stiffness: 350,
+                                        damping: 25,
+                                        mass: 0.8,
+                                        delay: 0.05
+                                    },
+                                    width: {
+                                        duration: dragging ? 0 : undefined,
+                                        type: dragging ? false : "spring",
+                                        stiffness: 350,
+                                        damping: 25,
+                                        mass: 0.8
+                                    },
+                                    height: {
+                                        duration: dragging ? 0 : undefined,
+                                        type: dragging ? false : "spring",
+                                        stiffness: 350,
+                                        damping: 25,
+                                        mass: 0.8
+                                    },
+                                    x: {
+                                        duration: dragging ? 0 : undefined,
+                                        type: dragging ? false : "spring",
+                                        stiffness: 350,
+                                        damping: 25,
+                                        mass: 0.8
+                                    },
+                                    y: {
+                                        duration: dragging ? 0 : undefined,
+                                        type: dragging ? false : "spring",
+                                        stiffness: 350,
+                                        damping: 25,
+                                        mass: 0.8
+                                    }
+                                }
+                            }
                             onMouseDown={handleMouseDown}
                             drag={!item.fixedSize}
                             dragControls={controls}

--- a/context/App.tsx
+++ b/context/App.tsx
@@ -62,7 +62,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         performanceBoost: false
     })
 
-    const [lastClickedElementRect, setLastClickedElementRect] = useState<{ x: number; y: number } | null>(null)
+    const lastClickedElementRect = useRef<{ x: number; y: number } | null>(null)
 
     const wallpapers = ['keyboard-garden', 'hogzilla', 'startup-monopoly', 'office-party', '2001-bliss', 'parade', 'coding-at-night']
 
@@ -239,7 +239,14 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
             let position = item.position
             if (!position) {
-                if (settings.topCenter && typeof window !== 'undefined') {
+                if (typeof window !== 'undefined' && window.innerWidth <= 768) {
+                    const inset = 0
+                    size = {
+                        width: window.innerWidth - inset * 2,
+                        height: window.innerHeight - inset * 2
+                    }
+                    position = { x: inset, y: inset }
+                } else if (settings.topCenter && typeof window !== 'undefined') {
                     position = { x: (window.innerWidth - size.width) / 2, y: 100 }
                 } else {
                     position = getPositionDefaults(size, prev)
@@ -258,16 +265,16 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
                 sizeConstraints: item.sizeConstraints || { min: MIN_SIZE, max: { width: 2000, height: 2000 } },
                 fixedSize: item.fixedSize || false,
                 minimal: item.minimal || false,
-                fromOrigin: lastClickedElementRect ? {
-                    x: lastClickedElementRect.x - size.width / 2,
-                    y: lastClickedElementRect.y - size.height / 2
+                fromOrigin: lastClickedElementRect.current ? {
+                    x: lastClickedElementRect.current.x - size.width / 2,
+                    y: lastClickedElementRect.current.y - size.height / 2
                 } : undefined
             }
 
             setFocusedWindow(newWindow)
             return [...prev, newWindow]
         })
-    }, [getPositionDefaults, getTitleFromPath, lastClickedElementRect, setFocusedWindowKey])
+    }, [getPositionDefaults, getTitleFromPath, setFocusedWindowKey])
 
     const closeWindow = useCallback((itemOrKey: string | AppWindow) => {
         const key = typeof itemOrKey === 'string' ? itemOrKey : itemOrKey.key
@@ -468,10 +475,10 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
             setCompact(window.innerWidth < 1024)
         }
 
-        const handleClick = (e: MouseEvent) => {
+        const handleMouseDown = (e: MouseEvent) => {
             const target = e.target as HTMLElement
             const rect = target.getBoundingClientRect()
-            setLastClickedElementRect({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 })
+            lastClickedElementRect.current = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
         }
 
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -506,12 +513,12 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
         handleResize()
         window.addEventListener('resize', handleResize)
-        window.addEventListener('click', handleClick)
+        window.addEventListener('mousedown', handleMouseDown, true)
         window.addEventListener('keydown', handleKeyDown)
 
         return () => {
             window.removeEventListener('resize', handleResize)
-            window.removeEventListener('click', handleClick)
+            window.removeEventListener('mousedown', handleMouseDown, true)
             window.removeEventListener('keydown', handleKeyDown)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This PR addresses user feedback regarding window opening animations, specifically focusing on the behavior of new windows and the fluidity of the animations.

**Key Changes:**
1. **Accurate Origin Tracking:** The `lastClickedElementRect` state was causing race conditions because it relied on `onClick` React events triggering state updates. This is now replaced with a `useRef` that uses a native `mousedown` event listener in the capture phase (`true`). This ensures the exact click origin is known *before* the `addWindow` call fires, allowing the window to reliably animate and grow from the clicked element.
2. **Instant Mobile Sizing:** Previously, windows on mobile devices opened instantly because a `useEffect` named `hasMobileAdjusted` was firing *after* the window mounted, causing the bounds to update aggressively and bypass the Framer Motion animation sequence. This logic has been moved upstream. Now, when a window is created via `addWindow`, if `window.innerWidth <= 768`, the full-screen dimensions are calculated instantly and provided as the starting size. The `hasMobileAdjusted` effect has been deleted.
3. **Fluid Spring Animations:** The hardcoded `duration: 0.2` and linear ease values for the window `scale`, `width`, `height`, `x`, and `y` properties have been upgraded to Framer Motion spring physics (`type: "spring", stiffness: 350, damping: 25, mass: 0.8`). This applies to both the `transition` config and the `exit` transition config, resulting in a much smoother, bouncy, "spatial UI" style interaction.

---
*PR created automatically by Jules for task [3695010444511424461](https://jules.google.com/task/3695010444511424461) started by @malidk345*