### PR TITLE
feat: Optimize viewport height and backdrop-blur for mobile and legacy browsers

### DIFF
--- a/app/blueprints/page.tsx
+++ b/app/blueprints/page.tsx
@@ -5,7 +5,7 @@ import Wrapper from '../../components/Wrapper'
 
 export default function Home() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/blueprints/post/[slug]/page.tsx
+++ b/app/blueprints/post/[slug]/page.tsx
@@ -7,7 +7,7 @@ export const runtime = 'edge';
 
 export default function Home() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-light px-6 text-center dark:bg-dark">
+        <div className="flex min-h-[100dvh] flex-col items-center justify-center bg-light px-6 text-center dark:bg-dark">
             <h1 className="text-9xl font-black text-burnt-orange opacity-20">404</h1>
             <div className="relative -mt-16">
                 <h2 className="mb-4 text-3xl font-bold text-primary-text lowercase tracking-tight">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function Home() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/posts/[slug]/page-client.tsx
+++ b/app/posts/[slug]/page-client.tsx
@@ -7,7 +7,7 @@ export default function PostPageClient({ initialPost }: { initialPost?: any }) {
     // to ensure the Blog view opens immediately with pre-fetched data.
     console.log('initialPost', initialPost);
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     );

--- a/app/posts/page-client.tsx
+++ b/app/posts/page-client.tsx
@@ -4,7 +4,7 @@ import Wrapper from "components/Wrapper"
 
 export default function PostsPageClient() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/profile/[username]/page-client.tsx
+++ b/app/profile/[username]/page-client.tsx
@@ -4,7 +4,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function PublicProfilePageClient() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -4,7 +4,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function ProfilePage() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/questions/[permalink]/page-client.tsx
+++ b/app/questions/[permalink]/page-client.tsx
@@ -4,7 +4,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function QuestionPermalinkPage() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/questions/page-client.tsx
+++ b/app/questions/page-client.tsx
@@ -4,7 +4,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function QuestionsPageClient() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/questions/topic/[slug]/page-client.tsx
+++ b/app/questions/topic/[slug]/page-client.tsx
@@ -4,7 +4,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function TopicPageClient() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/app/u/[username]/page-client.tsx
+++ b/app/u/[username]/page-client.tsx
@@ -4,7 +4,7 @@ import Wrapper from 'components/Wrapper'
 
 export default function CorpusPageClient() {
     return (
-        <main className="h-screen w-screen overflow-hidden bg-light dark:bg-dark">
+        <main className="h-[100dvh] w-screen overflow-hidden bg-light dark:bg-dark">
             <Wrapper />
         </main>
     )

--- a/components/ActiveWindowsPanel/index.tsx
+++ b/components/ActiveWindowsPanel/index.tsx
@@ -55,7 +55,7 @@ export default function ActiveWindowsPanel() {
             onClose={closeActiveWindowsPanel}
             title="active tasks"
             width="w-[340px] max-w-[calc(100vw-1rem)]"
-            panelClassName="h-[calc(100vh-44px-0.75rem)] max-h-[calc(100vh-44px-0.75rem)] sm:h-[calc(100vh-2rem-44px)] sm:max-h-[calc(100vh-2rem-44px)] !border-primary/30 shadow-[0_20px_40px_-15px_rgba(0,0,0,0.2)] backdrop-blur-xl bg-white/90 dark:bg-zinc-900/90"
+            panelClassName="h-[calc(100dvh-44px-0.75rem)] max-h-[calc(100dvh-44px-0.75rem)] sm:h-[calc(100dvh-2rem-44px)] sm:max-h-[calc(100dvh-2rem-44px)] !border-primary/30 shadow-[0_20px_40px_-15px_rgba(0,0,0,0.2)] supports-[backdrop-filter]:backdrop-blur-xl bg-white/90 dark:bg-zinc-900/90"
         >
             <div className="h-full flex flex-col font-mono">
                 <ScrollArea className="px-2 py-3 h-full">
@@ -118,7 +118,7 @@ export default function ActiveWindowsPanel() {
                 </ScrollArea>
 
                 {totalWindows > 0 && (
-                    <div className="p-3 mt-auto border-t border-primary/20 bg-primary/5 backdrop-blur-md">
+                    <div className="p-3 mt-auto border-t border-primary/20 bg-primary/5 supports-[backdrop-filter]:backdrop-blur-md">
                         <div className="flex items-center justify-between mb-2">
                             <h3 className="text-[10px] font-black opacity-50 tracking-widest uppercase m-0 leading-none">session</h3>
                             <span className="text-[10px] font-bold text-primary/70 tracking-widest">

--- a/components/AdminPanel/RichTextEditor.tsx
+++ b/components/AdminPanel/RichTextEditor.tsx
@@ -523,7 +523,7 @@ const RichTextEditor = ({
     }, [handleKeyDown])
 
     return (
-        <div className={`${hideBorder ? 'bg-transparent overflow-hidden flex flex-col' : `border border-[#1E2F46]/15 rounded-sm bg-white overflow-hidden flex flex-col`} ${focusMode ? 'h-screen fixed inset-0 z-[100]' : (expandHeight ? 'h-auto' : 'h-full')}`}>
+        <div className={`${hideBorder ? 'bg-transparent overflow-hidden flex flex-col' : `border border-[#1E2F46]/15 rounded-sm bg-white overflow-hidden flex flex-col`} ${focusMode ? 'h-[100dvh] fixed inset-0 z-[100]' : (expandHeight ? 'h-auto' : 'h-full')}`}>
             {/* Toolkit - injected into Window Footer or Header via portal */}
             <Toolkit
                 windowKey={windowKey || targetKey}

--- a/components/AdminPanel/index.tsx
+++ b/components/AdminPanel/index.tsx
@@ -320,7 +320,7 @@ const AdminPanel = ({ item }: { item?: AppWindow }) => {
                         </div>
 
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                            <div className="p-4 border border-black/10 rounded-sm bg-white/50 backdrop-blur-sm flex flex-col gap-4">
+                            <div className="p-4 border border-black/10 rounded-sm bg-white/50 supports-[backdrop-filter]:backdrop-blur-sm flex flex-col gap-4">
                                 <h3 className="text-[11px] font-black tracking-widest text-black/40 flex items-center gap-2 lowercase">
                                     <IconTerminal className="size-3.5" /> system environment
                                 </h3>
@@ -343,7 +343,7 @@ const AdminPanel = ({ item }: { item?: AppWindow }) => {
                                 </div>
                             </div>
 
-                            <div className="p-4 border border-black/10 rounded-sm bg-white/50 backdrop-blur-sm flex flex-col gap-4">
+                            <div className="p-4 border border-black/10 rounded-sm bg-white/50 supports-[backdrop-filter]:backdrop-blur-sm flex flex-col gap-4">
                                 <h3 className="text-[11px] font-black tracking-widest text-black/40 flex items-center gap-2 lowercase">
                                     <IconActivity className="size-3.5" /> recently active
                                 </h3>
@@ -1079,7 +1079,7 @@ const AdminPanel = ({ item }: { item?: AppWindow }) => {
     return (
         <div className="flex flex-col md:flex-row w-full bg-[#f8fafb] text-black overflow-hidden font-sans h-full">
             {/* Sidebar */}
-            <div className="flex-shrink-0 border-b md:border-b-0 md:border-r border-black/5 bg-white/50 backdrop-blur-md flex flex-row md:flex-col overflow-x-auto md:overflow-visible py-2 px-2 md:py-6 md:px-0 md:w-44 no-scrollbar">
+            <div className="flex-shrink-0 border-b md:border-b-0 md:border-r border-black/5 bg-white/50 supports-[backdrop-filter]:backdrop-blur-md flex flex-row md:flex-col overflow-x-auto md:overflow-visible py-2 px-2 md:py-6 md:px-0 md:w-44 no-scrollbar">
                 <div className="hidden md:block px-5 mb-8">
                     <div className="flex items-center gap-2">
                         <div className="size-2 rounded-full bg-black/80" />

--- a/components/AppWindow/WindowRouter.tsx
+++ b/components/AppWindow/WindowRouter.tsx
@@ -487,7 +487,7 @@ function WriteRouteView({ nodeId, item, readOnly = false }: { nodeId?: string; i
                     <div className={`w-full max-w-4xl mx-auto px-4 sm:px-6 pb-20 flex-1 flex flex-col min-h-0 ${coverImage ? 'pt-8' : 'pt-12'}`}>
                         <div className="relative flex flex-col mb-8 shrink-0">
                             <div className={`relative ${coverImage ? '-mt-16 sm:-mt-20 mb-4' : 'mb-2'}`}>
-                                <div className={`rounded-lg p-3 -ml-3 block w-fit ${coverImage ? 'bg-white/10 backdrop-blur-xl shadow-lg border border-white/20 z-10' : ''}`}>
+                                <div className={`rounded-lg p-3 -ml-3 block w-fit ${coverImage ? 'bg-white/10 supports-[backdrop-filter]:backdrop-blur-xl shadow-lg border border-white/20 z-10' : ''}`}>
                                     {React.createElement(ICONS[iconIndex].IconNode, { className: `size-12 sm:size-16 ${ICONS[iconIndex].color}` })}
                                 </div>
                             </div>
@@ -525,7 +525,7 @@ function WriteRouteView({ nodeId, item, readOnly = false }: { nodeId?: string; i
                         <img src={coverImage} alt="Cover" className="w-full h-full object-cover" />
                         <button
                             onClick={() => setCoverImage(null)}
-                            className="absolute top-4 right-4 bg-black/60 text-white text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity backdrop-blur-md font-bold lowercase"
+                            className="absolute top-4 right-4 bg-black/60 text-white text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity supports-[backdrop-filter]:backdrop-blur-md font-bold lowercase"
                         >
                             remove cover
                         </button>

--- a/components/Contact/ContactContent.tsx
+++ b/components/Contact/ContactContent.tsx
@@ -71,7 +71,7 @@ export default function ContactContent() {
 
     return (
         <div className="h-full flex flex-col lowercase font-sans">
-            <div className="p-6 border-b border-primary/10 bg-accent/40 backdrop-blur-md">
+            <div className="p-6 border-b border-primary/10 bg-accent/40 supports-[backdrop-filter]:backdrop-blur-md">
                 <div className="flex items-center gap-4 mb-3">
                     <div className="size-12 rounded-lg bg-primary border border-border shadow-[0_2px_8px_rgba(0,0,0,0.04)] flex items-center justify-center text-primary">
                         <Mail className="size-6 opacity-80" />

--- a/components/Profile/PublicProfile.tsx
+++ b/components/Profile/PublicProfile.tsx
@@ -730,7 +730,7 @@ export default function PublicProfile({ username }: PublicProfileProps) {
                                                                 e.stopPropagation()
                                                                 openNodeEditor(node)
                                                             }}
-                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 backdrop-blur hover:text-primary"
+                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 supports-[backdrop-filter]:backdrop-blur hover:text-primary"
                                                             aria-label={`edit ${node.title}`}
                                                             title="edit node"
                                                         >
@@ -742,7 +742,7 @@ export default function PublicProfile({ username }: PublicProfileProps) {
                                                                 e.stopPropagation()
                                                                 void handleDeleteNode(node)
                                                             }}
-                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 backdrop-blur hover:text-red-600"
+                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 supports-[backdrop-filter]:backdrop-blur hover:text-red-600"
                                                             aria-label={`delete ${node.title}`}
                                                             title="delete node"
                                                         >
@@ -788,7 +788,7 @@ export default function PublicProfile({ username }: PublicProfileProps) {
                                                                 e.stopPropagation()
                                                                 handleEditPost(post)
                                                             }}
-                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 backdrop-blur hover:text-primary"
+                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 supports-[backdrop-filter]:backdrop-blur hover:text-primary"
                                                             aria-label={`edit ${post.title}`}
                                                             title="edit post"
                                                         >
@@ -800,7 +800,7 @@ export default function PublicProfile({ username }: PublicProfileProps) {
                                                                 e.stopPropagation()
                                                                 void handleDeletePost(post)
                                                             }}
-                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 backdrop-blur hover:text-red-600"
+                                                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/10 bg-white/80 text-primary/60 supports-[backdrop-filter]:backdrop-blur hover:text-red-600"
                                                             aria-label={`delete ${post.title}`}
                                                             title="delete post"
                                                         >

--- a/components/RadixUI/MenuBar.tsx
+++ b/components/RadixUI/MenuBar.tsx
@@ -187,7 +187,7 @@ const MenuItem: React.FC<{
                     )}
                     <Menubar.Portal>
                         <Menubar.SubContent className={ContentClasses} alignOffset={-5} data-scheme="primary">
-                            <ScrollArea className="max-h-screen !overflow-y-auto">
+                            <ScrollArea className="max-h-[100dvh] !overflow-y-auto">
                                 {item.items.map((subItem, subIndex) => (
                                     <MenuItem
                                         key={`${subItem.link}-${subIndex}`}

--- a/components/Search/SearchContext.tsx
+++ b/components/Search/SearchContext.tsx
@@ -106,7 +106,7 @@ export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
                                 leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                             >
-                                <Dialog.Panel className="w-full max-w-4xl md:mx-4 h-[90vh] md:h-[600px] z-[999998]">
+                                <Dialog.Panel className="w-full max-w-4xl md:mx-4 h-[90dvh] md:h-[600px] z-[999998]">
 
                                     {(() => {
                                         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/components/SidePanel/index.tsx
+++ b/components/SidePanel/index.tsx
@@ -53,7 +53,7 @@ export default function SidePanel({
                     animate={{ x: 0 }}
                     exit={{ x: '110%' }}
                     transition={{ duration: 0.3, type: 'tween', ease: 'easeOut' }}
-                    className={`fixed top-[calc(44px+0.5rem)] sm:top-[calc(44px+1rem)] right-2 sm:right-4 h-auto max-h-[90vh] sm:h-[calc(100vh-2rem-44px)] ${width} bg-white dark:bg-zinc-900 border border-primary rounded-md shadow-2xl z-[10000] flex flex-col text-primary overflow-hidden ${panelClassName}`}
+                    className={`fixed top-[calc(44px+0.5rem)] sm:top-[calc(44px+1rem)] right-2 sm:right-4 h-auto max-h-[90dvh] sm:h-[calc(100dvh-2rem-44px)] ${width} bg-white dark:bg-zinc-900 border border-primary rounded-md shadow-2xl z-[10000] flex flex-col text-primary overflow-hidden ${panelClassName}`}
                 >
                     <div className="h-full flex flex-col">
                         {(title || showCloseButton) && (

--- a/components/TaskBarMenu/index.tsx
+++ b/components/TaskBarMenu/index.tsx
@@ -256,7 +256,7 @@ export default function TaskBarMenu() {
                 ref={taskbarRef}
                 id="taskbar"
                 data-scheme="primary"
-                className="w-full bg-accent/90 backdrop-blur-md border-b border-primary top-0 z-[9999] flex justify-between pl-0.5 pr-2 items-center"
+                className="w-full bg-accent/90 supports-[backdrop-filter]:backdrop-blur-md border-b border-primary top-0 z-[9999] flex justify-between pl-0.5 pr-2 items-center"
             >
                 <div className="flex items-center gap-2 px-3 py-1 pointer-events-none">
                     <svg viewBox="0 0 32 32" className="size-5 fill-current text-black dark:text-white">


### PR DESCRIPTION
This PR applies two crucial browser-specific optimizations recommended for modern Next.js/Tailwind CSS applications:
1. Replaced all occurrences of `100vh` and `h-screen` with `100dvh` (and `h-[100dvh]`). This resolves layout jumps and bottom-menu clipping issues common in mobile browsers (like iOS Safari) where the UI address bar dynamically resizes the viewport.
2. Implemented `@supports` feature queries for `backdrop-blur` utility classes using Tailwind's arbitrary variant syntax (`supports-[backdrop-filter]:backdrop-blur-md`). This ensures the glassmorphism effect is only applied when the browser engine explicitly supports it, offering a graceful fallback.

Additionally, added `@eslint/eslintrc` to `package.json` to resolve a flat-config parsing error that was breaking `npm run lint`.

---
*PR created automatically by Jules for task [8906387884694139803](https://jules.google.com/task/8906387884694139803) started by @malidk345*