### PR TITLE
Fix toolbar visibility at the bottom of windows and posts

### DIFF
--- a/components/AppWindow/index.tsx
+++ b/components/AppWindow/index.tsx
@@ -666,7 +666,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                     )}
                                 </div>
                             </div>
-                            <div id={`window-footer-${item.key}`} className="w-full bg-transparent empty:hidden flex-shrink-0 pb-0.5" />
+                            <div id={`window-footer-${item.key}`} className="w-full bg-transparent flex-shrink-0 pb-0.5" />
 
                             {!item.fixedSize && !item.minimal && (
                                 <>


### PR DESCRIPTION
Removed the `empty:hidden` class from the `#window-footer-${item.key}` element inside `AppWindow` to fix an issue where the toolbar at the bottom of windows and posts was not displaying. Since the footer content is injected using a React Portal from `FooterBar.tsx`, the `empty:hidden` class would evaluate before React finishes mounting the children, leaving the container with `display: none`. Removing it resolves the problem without any unintended visual issues.

---
*PR created automatically by Jules for task [14619647550554408757](https://jules.google.com/task/14619647550554408757) started by @malidk345*