### PR TITLE
Fix broken glassmorphism in app windows due to invalid rgba() syntax

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -27,7 +27,7 @@ body {
 
 ::-webkit-scrollbar-track {
   background: transparent;
-  box-shadow: inset 1px 0 0 rgba(var(--primary-rgb), 0.05);
+  box-shadow: inset 1px 0 0 rgb(var(--primary-rgb) / 0.05);
 }
 
 .dark ::-webkit-scrollbar-track {
@@ -35,12 +35,12 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(var(--color-primary-rgb), 0.1);
+  background: rgb(var(--color-primary-rgb) / 0.1);
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(var(--color-primary-rgb), 0.2);
+  background: rgb(var(--color-primary-rgb) / 0.2);
 }
 
 .dark ::-webkit-scrollbar-thumb {
@@ -159,14 +159,14 @@ mark {
   .backdrop-blur-3xl-safe {
     backdrop-filter: blur(40px) saturate(180%);
     -webkit-backdrop-filter: blur(40px) saturate(180%);
-    background-color: rgba(var(--bg-rgb), 0.65);
+    background-color: rgb(var(--bg-rgb) / 0.65);
   }
 
   .glass-card {
-    background: rgba(var(--bg-rgb), 0.6);
+    background: rgb(var(--bg-rgb) / 0.6);
     backdrop-filter: blur(60px) saturate(200%);
     -webkit-backdrop-filter: blur(60px) saturate(200%);
-    border: 1px solid rgba(var(--primary-rgb), 0.05);
+    border: 1px solid rgb(var(--primary-rgb) / 0.05);
     box-shadow:
       inset 0 1px 0 0 rgba(255, 255, 255, 0.2),
       inset 0 0 0 1px rgba(255, 255, 255, 0.05),


### PR DESCRIPTION
This PR fixes the broken glassmorphism issue across the application's windows. 

**Root Cause:**
A recent change updated the core color variables (like `--bg-rgb`, `--primary-rgb`) to use space-separated values (e.g., `255 255 255`) instead of comma-separated ones, which is standard for Tailwind configurations. However, several custom classes in `app/globals.css` (specifically `.glass-card`, `.backdrop-blur-3xl-safe`, and the scrollbar styles) were still trying to use them inside the legacy `rgba(var(--variable), opacity)` function. This resulted in invalid CSS syntax (e.g., `rgba(255 255 255, 0.6)`), causing the browser to entirely drop those background and shadow rules.

**Solution:**
Replaced all instances of `rgba(var(--variable), opacity)` with the modern CSS Color Level 4 syntax: `rgb(var(--variable) / opacity)`. This successfully parses the space-separated variables and restores the intended transparencies, re-enabling the frosted glass backgrounds for the OS windows.

Visually verified using Playwright screenshots.

---
*PR created automatically by Jules for task [8901723039004969856](https://jules.google.com/task/8901723039004969856) started by @malidk345*