### PR TITLE
feat: update search window to iOS 26 spatial aesthetic

### DIFF
--- a/components/Search/SearchUI.tsx
+++ b/components/Search/SearchUI.tsx
@@ -68,16 +68,16 @@ export const WindowSearchUI = ({ initialFilter }: { initialFilter?: string }) =>
     }
 
     return (
-        <div className="flex flex-col h-full bg-primary overflow-hidden">
+        <div className="flex flex-col h-full bg-transparent overflow-hidden">
             {/* Search Input */}
-            <div className="flex-shrink-0 p-2 border-b border-border bg-accent/30">
-                <div className="flex items-center gap-2 bg-primary border border-border rounded px-2 py-1.5">
-                    <IconSearch className="size-4 text-muted flex-shrink-0" />
+            <div className="flex-shrink-0 p-3 pb-2">
+                <div className="flex items-center gap-2 bg-white/50 dark:bg-black/50 supports-[backdrop-filter]:backdrop-blur-xl border border-black/10 dark:border-white/10 rounded-full px-3 py-2 shadow-inner">
+                    <IconSearch className="size-4 text-muted flex-shrink-0 ml-1" />
                     <input
                         ref={inputRef}
                         type="text"
-                        className="flex-1 bg-transparent border-0 outline-none text-sm text-primary placeholder:text-muted"
-                        placeholder="search blog posts..."
+                        className="flex-1 bg-transparent border-0 outline-none text-[15px] text-primary placeholder:text-muted"
+                        placeholder="Search blog posts..."
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
                         autoFocus
@@ -85,58 +85,58 @@ export const WindowSearchUI = ({ initialFilter }: { initialFilter?: string }) =>
                     {query && (
                         <button
                             onClick={() => setQuery('')}
-                            className="text-muted hover:text-primary text-xs px-1"
+                            className="flex items-center justify-center size-5 rounded-full bg-black/10 dark:bg-white/10 text-muted hover:text-primary transition-colors hover:bg-black/20 dark:hover:bg-white/20 mr-1"
                         >
-                            ✕
+                            <span className="text-[10px] font-bold">✕</span>
                         </button>
                     )}
                 </div>
             </div>
 
             {/* Results */}
-            <div className="flex-1 overflow-y-auto">
+            <div className="flex-1 overflow-y-auto px-2 pb-2">
                 {loading ? (
-                    <div className="p-4 text-center text-muted text-sm">
-                        loading posts...
+                    <div className="p-4 text-center text-muted text-sm bg-white/40 dark:bg-black/40 supports-[backdrop-filter]:backdrop-blur-xl rounded-[18px] mx-1 mt-1 border border-black/5 dark:border-white/5">
+                        Loading posts...
                     </div>
                 ) : query.length < 2 ? (
-                    <div className="p-4 text-center text-muted text-sm">
-                        type at least 2 characters to search...
+                    <div className="p-4 text-center text-muted text-sm bg-white/40 dark:bg-black/40 supports-[backdrop-filter]:backdrop-blur-xl rounded-[18px] mx-1 mt-1 border border-black/5 dark:border-white/5">
+                        Type at least 2 characters to search...
                     </div>
                 ) : results.length === 0 ? (
-                    <div className="p-4 text-center text-muted text-sm">
-                        no results found for &quot;{query}&quot;
+                    <div className="p-4 text-center text-muted text-sm bg-white/40 dark:bg-black/40 supports-[backdrop-filter]:backdrop-blur-xl rounded-[18px] mx-1 mt-1 border border-black/5 dark:border-white/5">
+                        No results found for &quot;{query}&quot;
                     </div>
                 ) : (
-                    <div className="divide-y divide-border">
-                        <div className="px-3 py-1.5 text-[11px] font-bold lowercase tracking-wider text-muted bg-accent/20">
-                            {results.length} result{results.length !== 1 ? 's' : ''}
+                    <div className="flex flex-col space-y-1">
+                        <div className="px-3 py-1 text-[11px] font-semibold tracking-wide text-muted/70">
+                            {results.length} RESULT{results.length !== 1 ? 'S' : ''}
                         </div>
                         {results.map((post) => (
                             <button
                                 key={post.id}
                                 onClick={() => handleResultClick(post)}
-                                className="w-full text-left px-3 py-2.5 hover:bg-accent/40 transition-colors block cursor-pointer"
+                                className="w-full text-left px-3 py-3 bg-white/60 dark:bg-black/40 supports-[backdrop-filter]:backdrop-blur-xl hover:bg-white/80 dark:hover:bg-black/60 transition-colors block cursor-pointer border border-black/5 dark:border-white/5 rounded-[18px] shadow-sm"
                             >
-                                <div className="flex items-start gap-2">
+                                <div className="flex items-start gap-3">
                                     <div className="flex-1 min-w-0">
                                         {post.category && (
-                                            <span className="text-[10px] font-bold lowercase tracking-wider text-orange opacity-80">
+                                            <span className="text-[10px] font-bold tracking-wider text-orange opacity-90 uppercase">
                                                 {post.category}
                                             </span>
                                         )}
-                                        <h4 className="text-sm font-semibold text-primary m-0 line-clamp-1">
+                                        <h4 className="text-[15px] font-semibold text-primary m-0 line-clamp-1 tracking-tight mt-0.5">
                                             {post.title}
                                         </h4>
-                                        <p className="text-xs text-secondary m-0 mt-0.5 line-clamp-2 opacity-70">
+                                        <p className="text-[13px] text-secondary m-0 mt-1 line-clamp-2 opacity-80 leading-snug">
                                             {getExcerpt(post.content, query)}
                                         </p>
-                                        <div className="flex items-center gap-2 mt-1">
+                                        <div className="flex items-center gap-2 mt-2">
                                             {post.date && (
-                                                <span className="text-[10px] text-muted">{post.date}</span>
+                                                <span className="text-[11px] text-muted/80 font-medium">{post.date}</span>
                                             )}
                                             {post.authorName && (
-                                                <span className="text-[10px] text-muted">by {post.authorName}</span>
+                                                <span className="text-[11px] text-muted/80">by {post.authorName}</span>
                                             )}
                                         </div>
                                     </div>
@@ -145,7 +145,7 @@ export const WindowSearchUI = ({ initialFilter }: { initialFilter?: string }) =>
                                         <img
                                             src={post.image}
                                             alt=""
-                                            className="w-12 h-12 rounded object-cover flex-shrink-0"
+                                            className="w-14 h-14 rounded-[12px] object-cover flex-shrink-0 border border-black/10 dark:border-white/10 shadow-sm"
                                         />
                                     )}
                                 </div>


### PR DESCRIPTION
This PR updates the internal search window (`SearchUI.tsx`) to match the user's requested 'VisionOS / iOS 26' spatial aesthetic. 

The update transitions the UI from an opaque, divided-list design to a deeply glassmorphic, card-based layout featuring pill-shaped inputs, highly rounded corners (`rounded-[18px]`), and spatial depth (`shadow-inner`). Visual verification was originally attempted but skipped per user agreement due to local environment configuration hurdles (Supabase/Upstash), but all linting and production builds pass successfully.

---
*PR created automatically by Jules for task [16891144125849369274](https://jules.google.com/task/16891144125849369274) started by @malidk345*