### PR TITLE
fix: resolve various lint warnings across the codebase

### DIFF
--- a/components/AmbientPlayer/index.tsx
+++ b/components/AmbientPlayer/index.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState, useRef, useEffect } from 'react'
-import { Headphones, Play, Square, Volume2, Loader2 } from 'lucide-react'
+import { Headphones, Volume2, Loader2 } from 'lucide-react'
 import OSButton from 'components/OSButton'
 import Tooltip from 'components/RadixUI/Tooltip'
 

--- a/components/Desktop/TrendingWidget.tsx
+++ b/components/Desktop/TrendingWidget.tsx
@@ -230,6 +230,7 @@ export default function TrendingWidget() {
                                     <Bell className="w-3 h-3 text-[#172b4d]" />
                                 </div>
                             ) : post.avatar_url ? (
+                                /* eslint-disable-next-line @next/next/no-img-element */
                                 <img
                                     src={post.avatar_url}
                                     alt={post.author}

--- a/components/Forum/ForumReplyCard.tsx
+++ b/components/Forum/ForumReplyCard.tsx
@@ -10,7 +10,6 @@ import VotePicker from 'components/VotePicker'
 import { IconPencil, IconTrash } from '@posthog/icons'
 import Link from 'components/Link'
 import { supabase } from 'lib/supabase'
-import { useToast } from 'context/ToastContext'
 import { useAuth } from 'context/AuthContext'
 import { useCommunity } from 'hooks/useCommunity'
 
@@ -22,7 +21,6 @@ interface ForumReplyCardProps {
 }
 
 export default function ForumReplyCard({ reply, postId, isInForum = false, questionAuthorId }: ForumReplyCardProps) {
-    const { addToast } = useToast()
     const { isAdmin } = useAuth()
     const { handleReplyVote, deleteReply } = useCommunity()
     const [userVote, setUserVote] = useState(0)

--- a/components/Ideas/AtmosphericStations.tsx
+++ b/components/Ideas/AtmosphericStations.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react'
 import { motion } from 'framer-motion'
-import { Monitor, Moon, Sun, Terminal, BookOpen, Coffee, Zap } from 'lucide-react'
+import { Monitor, Moon, Terminal, BookOpen, Coffee, Zap } from 'lucide-react'
 import { useApp } from 'context/App'
 import ScrollArea from 'components/RadixUI/ScrollArea'
 import OSButton from 'components/OSButton'

--- a/components/Ideas/CuratedDossiers.tsx
+++ b/components/Ideas/CuratedDossiers.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react'
 import ScrollArea from 'components/RadixUI/ScrollArea'
-import { Folder, FolderOpen, FileText, ChevronRight, Hash } from 'lucide-react'
+import { Folder, FolderOpen, FileText } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 
 const MOCK_DOSSIERS = [

--- a/components/Ideas/Marginalia.tsx
+++ b/components/Ideas/Marginalia.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from 'react'
 import ScrollArea from 'components/RadixUI/ScrollArea'
-import OSButton from 'components/OSButton'
 import { FileText, ExternalLink, Bookmark } from 'lucide-react'
 
 const MOCK_NOTES = [

--- a/components/NotificationCenter/index.tsx
+++ b/components/NotificationCenter/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Bell, X, MessageSquare, Newspaper, Zap, Info } from 'lucide-react'
+import { Bell, X, MessageSquare, Newspaper } from 'lucide-react'
 import { supabase } from 'lib/supabase'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'

--- a/context/App.tsx
+++ b/context/App.tsx
@@ -327,7 +327,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         setWindows((prev) => prev.map(w => w.key === key ? { ...w, ref } : w))
     }, [])
 
-    const openSearch = useCallback((_filter?: string) => {
+    const openSearch = useCallback(() => {
         const size = isMobile
             ? { width: typeof window !== 'undefined' ? Math.min(window.innerWidth - 32, 500) : 400, height: 320 }
             : { width: 600, height: 400 }

--- a/context/Window.tsx
+++ b/context/Window.tsx
@@ -77,6 +77,7 @@ export const WindowProvider = ({
     children: React.ReactNode
     value?: Partial<WindowContextType>
 }) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const addWindow = (_newWindow: Omit<AppWindow, 'zIndex' | 'minimized' | 'sizeConstraints' | 'size' | 'previousSize' | 'position' | 'previousPosition' | 'fixedSize' | 'minimal'>) => {
     };
 


### PR DESCRIPTION
This PR resolves a series of lint warnings found across the codebase. Specifically, it removes unused variables, unused imports, unused hooks, and applies correct eslint-disable comments for intended implementations (like `<img>` tags for external images).

* Removed unused imports (`Play`, `Square`, `Sun`, `ChevronRight`, `Hash`, `OSButton`, `Zap`, `Info`) from components in `AmbientPlayer`, `Ideas`, and `NotificationCenter`.
* Handled `@next/next/no-img-element` warning in `TrendingWidget` where `next/image` is intentionally bypassed.
* Cleaned up unused `addToast` state extraction from `useToast` hook in `ForumReplyCard`.
* Removed unused function parameters in `context/App.tsx` and suppressed context placeholder warning in `context/Window.tsx`.

---
*PR created automatically by Jules for task [11818021660428740573](https://jules.google.com/task/11818021660428740573) started by @malidk345*