### PR TITLE
Fix Supabase auth redirects for preview deployments

### DIFF
--- a/components/Posts/index.tsx
+++ b/components/Posts/index.tsx
@@ -8,7 +8,8 @@ import {
     IconPerson,
 } from '@posthog/icons'
 import { useApp } from 'context/App'
-import { usePosts, Post } from 'hooks/usePosts'
+import { usePosts } from 'hooks/usePosts'
+import type { Post } from 'types/database'
 import ScrollArea from 'components/RadixUI/ScrollArea'
 import BlogPostView from 'components/ReaderView/BlogPostView'
 import SEO from 'components/SEO'

--- a/components/Search/SearchUI.tsx
+++ b/components/Search/SearchUI.tsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect, useRef, useMemo } from 'react'
 import { useWindow } from '../../context/Window'
 import { useApp } from '../../context/App'
 import { IconSearch } from '@posthog/icons'
-import { usePosts, Post } from '../../hooks/usePosts'
+import { usePosts } from '../../hooks/usePosts'
+import type { Post } from '../../types/database'
 
 // Simple local search function
 function searchPosts(allPosts: Post[], query: string) {

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -251,7 +251,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 options: {
                     data: {
                         username: trimmedEmail.split('@')[0],
-                    }
+                    },
+                    emailRedirectTo: typeof window !== 'undefined' ? window.location.origin : undefined,
                 },
             });
 


### PR DESCRIPTION
Updated `signInWithOtp` options to include `emailRedirectTo` using `window.location.origin` to support authentication redirects in preview deployments like Cloudflare Pages or Vercel.

**Important Note for the User**: To make this work, you must also add your wildcard preview domains (e.g., `https://*.pages.dev/*` or `https://*.vercel.app/*`) in your Supabase Dashboard -> Authentication -> URL Configuration -> Redirect URLs.

---
*PR created automatically by Jules for task [11482538333536704550](https://jules.google.com/task/11482538333536704550) started by @malidk345*