### PR TITLE
Revert pure typography styling (V2)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -773,8 +773,8 @@ mark {
   h5,
   h6 {
     @apply font-bold;
-    letter-spacing: -0.025em;
-    font-variation-settings: 'wght' 700;
+    letter-spacing: -0.015rem;
+    font-variation-settings: 'wght' 800;
     font-family: var(--font-ibm-plex), -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'segoe ui', 'helvetica neue', helvetica, Ubuntu, roboto, noto, arial, sans-serif !important;
   }
 


### PR DESCRIPTION
This PR specifically reverts pure typography styling while preserving all spatial UI enhancements (layout, padding, blurs, border-radius, glassmorphism, dvh).

### Reverted Typography Changes:
1.  **app/globals.css**:
    *   Header (`h1` through `h6`) `letter-spacing` reverted from `-0.025em` to `-0.015rem`.
    *   Header `font-variation-settings` reverted from `'wght' 700` to `'wght' 800`.
2.  **components/Search/SearchUI.tsx**:
    *   Search input font size: ensured `text-sm`.
    *   Result titles (`h4`): ensured `text-sm`.
    *   Excerpt text (`p`): ensured `text-xs`.
    *   Category tags: ensured `lowercase`.

### Intact Enhancements:
*   Layout, padding, and container styling.
*   Safe blurs and glassmorphism.
*   Border-radius settings.
*   Viewport height (`dvh`) and package updates.