### PR TITLE
style(blueprints): apply Vision OS / iOS 26 glassmorphic UI aesthetic

### DIFF
--- a/components/Blueprints/BlueprintPostView.tsx
+++ b/components/Blueprints/BlueprintPostView.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React, { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
 import { useBlueprints, BlueprintPost } from 'hooks/useBlueprints'
 import Loading from 'components/Loading'
 import { sanitizeHtml } from 'utils/security'
@@ -21,23 +22,28 @@ export default function BlueprintPostView({ slug }: { slug: string }) {
     if (!post) return <div className="p-8 text-center lowercase">blueprint not found</div>
 
     return (
-        <div className="absolute inset-0 overflow-auto bg-white dark:bg-black">
+        <div className="absolute inset-0 overflow-auto bg-transparent">
             {post.custom_css && (
                 <style dangerouslySetInnerHTML={{ __html: post.custom_css }} />
             )}
             
-            <div className="blueprint-canvas h-full w-full">
+            <motion.div
+                className="blueprint-canvas h-full w-full relative z-10"
+                initial={{ opacity: 0, y: 15 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, type: 'spring', bounce: 0.1 }}
+            >
                 {post.content_html ? (
                     <div 
-                        className="w-full h-full"
+                        className="w-full h-full prose prose-sm md:prose-base dark:prose-invert max-w-3xl mx-auto p-6 md:p-12 blueprint-prose"
                         dangerouslySetInnerHTML={{ __html: sanitizeHtml(post.content_html) }} 
                     />
                 ) : (
-                    <div className="prose prose-sm max-w-none p-12">
+                    <div className="prose prose-sm md:prose-base dark:prose-invert max-w-3xl mx-auto p-6 md:p-12 blueprint-prose">
                         {post.content_markdown}
                     </div>
                 )}
-            </div>
+            </motion.div>
         </div>
     )
 }

--- a/components/Blueprints/BlueprintsExplorer.tsx
+++ b/components/Blueprints/BlueprintsExplorer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React, { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
 import { useBlueprints, BlueprintPost } from 'hooks/useBlueprints'
 import ScrollArea from 'components/RadixUI/ScrollArea'
 import Loading from 'components/Loading'
@@ -35,7 +36,7 @@ export default function BlueprintsExplorer() {
     if (loading) return <Loading fullScreen label="scanning blueprints" />
 
     return (
-        <div className="absolute inset-0 bg-primary flex flex-col font-mono lowercase">
+        <div className="absolute inset-0 bg-transparent flex flex-col font-mono lowercase">
             <ScrollArea>
                 <div className="max-w-4xl mx-auto py-12 px-6">
                     <header className="mb-12 border-b border-primary/10 pb-6">
@@ -48,15 +49,21 @@ export default function BlueprintsExplorer() {
                     <div className="space-y-12">
                         {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                         {hierarchy.map((category: any) => (
-                            <section key={category.id} className="blueprint-category">
-                                <h2 className="text-xs font-black tracking-widest uppercase opacity-30 mb-6 border-l-2 border-primary pl-4">
+                            <motion.section
+                                key={category.id}
+                                className="blueprint-category"
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.5, type: 'spring', bounce: 0.2 }}
+                            >
+                                <h2 className="text-xs font-black tracking-widest uppercase opacity-40 mb-6 inline-block bg-black/5 dark:bg-white/10 px-4 py-1.5 rounded-full">
                                     {category.name}
                                 </h2>
                                 
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                                     {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                                     {category.lectures?.map((lecture: any) => (
-                                        <div key={lecture.id} className="bg-accent/50 border border-primary/10 rounded-sm p-4 hover:border-primary/30 transition-colors">
+                                        <div key={lecture.id} className="bg-white/40 dark:bg-white/5 border border-black/5 dark:border-white/10 rounded-[24px] shadow-sm supports-[backdrop-filter]:backdrop-blur-xl p-6 hover:bg-white/60 dark:hover:bg-white/10 transition-all duration-300">
                                             <h3 className="text-sm font-bold flex items-center gap-2 mb-3">
                                                 <BookOpen className="size-4 opacity-50" /> {lecture.name}
                                             </h3>
@@ -66,7 +73,7 @@ export default function BlueprintsExplorer() {
                                                     <li 
                                                         key={post.id}
                                                         onClick={() => handlePostClick(post)}
-                                                        className="text-[11px] opacity-60 hover:opacity-100 hover:text-blue-500 cursor-pointer flex items-center gap-1 group"
+                                                        className="text-[12px] opacity-70 hover:opacity-100 cursor-pointer flex items-center gap-2 group py-1.5 px-2 hover:bg-black/5 dark:hover:bg-white/10 rounded-xl transition-colors"
                                                     >
                                                         <ChevronRight className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                                                         {post.title}
@@ -76,7 +83,7 @@ export default function BlueprintsExplorer() {
                                         </div>
                                     ))}
                                 </div>
-                            </section>
+                            </motion.section>
                         ))}
                     </div>
                 </div>


### PR DESCRIPTION
- Refactor \`BlueprintsExplorer\` with \`bg-transparent\`, rounded capsules, and glassmorphic lecture cards (\`bg-white/40\`, \`backdrop-blur-xl\`, etc.).
- Convert \`BlueprintPostView\` container to transparent, adjust layout dimensions and padding for the prose container.
- Introduce \`framer-motion\` animations for spring-like mount entry transitions to category containers and post canvas.

---
*PR created automatically by Jules for task [1076841561648368655](https://jules.google.com/task/1076841561648368655) started by @malidk345*