### PR TITLE
style(profile): implement iOS 26 aesthetics for profile windows

### DIFF
--- a/components/Corpus/styles.css
+++ b/components/Corpus/styles.css
@@ -327,12 +327,15 @@
   }
 
   .corpus-profile-slot {
-    background: color-mix(in hsl, canvas, canvasText 2%);
-    border: 1px solid color-mix(in hsl, canvas, canvasText 10%);
-    border-radius: 6px;
+    background: rgb(var(--bg-rgb) / 0.6);
+    backdrop-filter: blur(60px) saturate(200%);
+    -webkit-backdrop-filter: blur(60px) saturate(200%);
+    border: 1px solid rgb(var(--primary-rgb) / 0.05);
+    border-radius: 32px;
     overflow: hidden;
     margin: 0;
     padding: 1rem;
+    box-shadow: 0 20px 40px -10px rgba(0, 0, 0, 0.1);
   }
 
   .corpus-profile-stack {
@@ -346,7 +349,7 @@
     position: relative;
     overflow: hidden;
     min-height: 136px;
-    border-radius: 6px;
+    border-radius: 24px;
     border: 1px solid color-mix(in hsl, canvas, canvasText 20%);
     background: color-mix(in hsl, canvas, canvasText 3%);
   }
@@ -401,7 +404,7 @@
     translate: 0 0;
     width: 64px;
     height: 64px;
-    border-radius: 12px;
+    border-radius: 50%;
     border: 2px solid light-dark(white, hsl(0 0% 0% / 0.4));
     background: color-mix(in hsl, canvas, canvasText 4%);
     overflow: hidden;
@@ -426,15 +429,15 @@
 
   .corpus-profile-tableCard,
   .corpus-profile-statusCard {
-    background: color-mix(in hsl, canvas, canvasText 2%);
-    border: 1px solid color-mix(in hsl, canvas, canvasText 18%);
-    border-radius: 6px;
+    background: rgb(var(--bg-rgb) / 0.4);
+    border: 1px solid rgb(var(--primary-rgb) / 0.05);
+    border-radius: 24px;
     overflow: hidden;
     position: relative;
   }
 
   .corpus-profile-cardShadow {
-    box-shadow: none;
+    box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.1);
   }
 
   .corpus-profile-cardHeading {
@@ -1190,9 +1193,9 @@
     display: grid;
     grid-template-rows: 1fr auto;
     padding: 0.375rem;
-    border: 1px solid color-mix(in hsl, canvas, canvasText 10%);
+    border: 1px solid rgb(var(--primary-rgb) / 0.05);
     border-radius: 24px;
-    background: color-mix(in hsl, canvas, canvasText 2%);
+    background: rgb(var(--bg-rgb) / 0.4);
     cursor: pointer;
     transition: border-color 0.2s, background 0.2s;
   }

--- a/components/Profile/PublicProfile.tsx
+++ b/components/Profile/PublicProfile.tsx
@@ -498,7 +498,7 @@ export default function PublicProfile({ username }: PublicProfileProps) {
         <div className="corpus-root flex flex-col size-full bg-white/80 dark:bg-black/80 supports-[backdrop-filter]:backdrop-blur-[60px] text-primary font-sans overflow-hidden">
             <div
                 data-scheme="tertiary"
-                className="flex w-auto mx-1 mt-1 items-center px-1.5 py-0.5 select-none gap-2 justify-between bg-white/80 dark:bg-black/80 supports-[backdrop-filter]:backdrop-blur-[60px] rounded-full shrink-0 z-10 h-10 overflow-x-auto custom-scrollbar no-scrollbar-on-mobile"
+                className="flex w-auto mx-1 mt-1 items-center px-1.5 py-0.5 select-none gap-2 justify-between rounded-full shrink-0 z-10 h-10 overflow-x-auto custom-scrollbar no-scrollbar-on-mobile"
             >
                 <div className="flex items-center gap-1 flex-shrink-0">
                     {isOwner && (


### PR DESCRIPTION
This pull request updates the profile components styling to implement the requested iOS 26 aesthetic. It introduces:

- High-radius corner smoothing (32px for window slots, 24px for inner table cards and statuses)
- Perfectly circular profile avatars (50% border radius)
- Deep glassmorphism styling utilizing `backdrop-filter: blur(60px)` and transparent RGB backgrounds matching the theme colors, resolving visual compactness and improving the Web and Mobile layouts
- Fixes to CSS variable application, ensuring `rgb(var(--bg-rgb) / 0.6)` syntax is correctly used for translucent styling based on the core directives.

---
*PR created automatically by Jules for task [6178478828420806866](https://jules.google.com/task/6178478828420806866) started by @malidk345*